### PR TITLE
removed slash

### DIFF
--- a/bin/topdoc
+++ b/bin/topdoc
@@ -69,6 +69,6 @@ if(!fs.existsSync(source)){
 
 	var topdoc = new Topdoc(options);
 	topdoc.generate((function(){
-		console.log('Generated documentation in ./' + destination);
+		console.log('Generated documentation in ' + destination);
 	}).bind(destination));
 }


### PR DESCRIPTION
If you specify a destination using `-d` you could get an output like `././docs`
