### PR TITLE
:bug: fix(51): Fixes #51 problem with asset copy

### DIFF
--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -53,7 +53,7 @@ program
     [/^\./, /^node_modules/, /\.pug/, /\.jade/, '/**/*.json'])
   .option('-a, --asset-directory [path]',
     `Path to directory of assets to copy to destination. Defaults to template directory.
-    Set to false to not copy any assets.`, _valOrFalse)
+    Set to false to not copy any assets.`, _valOrFalse, true)
   .version(module.exports.version)
   .parse(process.argv);
 
@@ -86,7 +86,7 @@ if (options.assetDirectory && !path.isAbsolute(options.assetDirectory)) {
       const mainFile = resolve.sync(options.assetDirectory, {
         basedir: process.cwd(),
         packageFilter: (pkg, resolvePath) => {
-          templateDirectory = resolvePath;
+          templateDirectory = path.resolve(resolvePath, 'lib');
           return pkg;
         },
       });

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -39,12 +39,6 @@ function _booleanOrValue(val) {
   return val;
 }
 
-// function _trueOrVal(val) {
-//   console.log('transform', val);
-//   if (val === 'true') return true;
-//   return val;
-// }
-
 // defaults defined here cannot be overridden by rc file
 program
   .description(module.exports.description)

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -76,10 +76,14 @@ optionDefaults.destination = path.resolve(process.cwd(), 'docs');
 optionDefaults.template = 'topdoc-default-template';
 optionDefaults.templateData = null;
 optionDefaults.clobber = false;
-optionDefaults.assetDirectory = optionDefaults.template;
 optionDefaults.stdout = false;
 
 const options = loadConfig('topdoc', optionDefaults, argParser(program));
+
+// if assets copy is enabled but no directory was defined be sure to use template
+if (!options.assetDirectory && options.assetDirectory !== false) {
+  options.assetDirectory = options.template;
+}
 
 // project is actually used for title by topdoc to template parser
 if (options.project) {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -55,7 +55,7 @@ test.cb('should accept new destination location', t => {
   .end(t.end);
 });
 
-test.cb('should allow for a project title', t => {
+test.cb('should change project name if passed a string', t => {
   const destination = path.resolve(baseDestination, randomstring.generate());
   const source = path.resolve(__dirname, 'fixtures', 'button.css');
   nixt()
@@ -64,6 +64,19 @@ test.cb('should allow for a project title', t => {
     t.regex(docFile, /<title>lalala<\/title>/);
   })
   .run(`topdoc ${source} -d ${destination} -p 'lalala'`)
+  .end(t.end);
+});
+
+
+test.cb('should use cwd for project name if passed true', t => {
+  const destination = path.resolve(baseDestination, randomstring.generate());
+  const source = path.resolve(__dirname, 'fixtures', 'button.css');
+  nixt()
+  .expect(() => {
+    const docFile = read(path.resolve(destination, 'index.html'));
+    t.regex(docFile, /<title>test<\/title>/);
+  })
+  .run(`topdoc ${source} -d ${destination} -p true`)
   .end(t.end);
 });
 

--- a/test/project.test.js
+++ b/test/project.test.js
@@ -15,6 +15,17 @@ function read(filepath) {
   return fs.readFileSync(filepath, 'utf-8');
 }
 
+test.cb('should error if pointed at directory with no files', t => {
+  const wrongPath = path.resolve(baseDestination, 'empty');
+  nixt()
+    .cwd(cwd)
+    .expect((result) => {
+      t.is(result.stderr.includes('Error: No files match'), true);
+    })
+    .run(`topdoc ${wrongPath}`)
+    .end(t.end);
+});
+
 
 test.cb('should build docs based on rc file config', t => {
   const destination = path.resolve(baseDestination, randomstring.generate());


### PR DESCRIPTION
Asset copy was failing if template was declared using the string name of another npm package

ISSUES CLOSED: #51 

HI @GarthDB I FIXED IT 😹 